### PR TITLE
Add INI struct reflection

### DIFF
--- a/example/click_example.cpp
+++ b/example/click_example.cpp
@@ -8,10 +8,22 @@
 
 #include <cpp-toolbox/logger/thread_logger.hpp>  // Include logger for output
 #include <cpp-toolbox/utils/click.hpp>
+#include <cpp-toolbox/utils/ini_config.hpp>
+#include <cpp-toolbox/utils/ini_struct.hpp>
 
 // Use namespaces for brevity
 using namespace toolbox::utils;
 using namespace toolbox::logger;
+
+struct basic_ini
+{
+  std::string key1;
+  int key2 = 0;
+};
+
+TOOLBOX_INI_STRUCT(basic_ini,
+    TOOLBOX_INI_FIELD(basic_ini, key1, "section1", "key1"),
+    TOOLBOX_INI_FIELD(basic_ini, key2, "section1", "key2"))
 
 /**
  * @brief Callback function for the 'process' subcommand.
@@ -101,10 +113,19 @@ int main(int argc, char** argv)
   auto& logger = thread_logger_t::instance();
   logger.set_level(thread_logger_t::Level::INFO);  // Set desired log level
 
+  ini_config_t ini_cfg;
+  ini_cfg.load("example.ini");
+
+  basic_ini cfg_struct{};
+  load_struct_from_ini(ini_cfg, cfg_struct);
+  LOG_INFO_S << "INI struct key1=" << cfg_struct.key1
+             << " key2=" << cfg_struct.key2;
+
   /** @brief Main application object */
   CommandLineApp app(
       "example_cli",
       "An example CLI application demonstrating click.hpp features.");
+  app.apply_ini_config(ini_cfg, "example_cli");
 
   // --- Global Options ---
   /** @brief Verbosity flag */

--- a/src/impl/cpp-toolbox/CMakeLists.txt
+++ b/src/impl/cpp-toolbox/CMakeLists.txt
@@ -21,6 +21,7 @@ set(cpp-toolbox_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/click.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/random.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/ini_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/io/pcd.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/io/kitti.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/io/kitti_pcd.cpp

--- a/src/impl/cpp-toolbox/utils/ini_config.cpp
+++ b/src/impl/cpp-toolbox/utils/ini_config.cpp
@@ -1,0 +1,72 @@
+#include <fstream>
+#include <sstream>
+
+#include <cpp-toolbox/logger/thread_logger.hpp>
+#include <cpp-toolbox/utils/ini_config.hpp>
+
+namespace toolbox::utils
+{
+bool ini_config_t::load(const std::string& file_path)
+{
+  std::ifstream ifs(file_path);
+  if (!ifs.is_open()) {
+    LOG_ERROR_S << "Failed to open config file: " << file_path;
+    return false;
+  }
+
+  std::string current_section;
+  std::string line;
+  while (std::getline(ifs, line)) {
+    // Trim whitespace
+    line.erase(0, line.find_first_not_of(" \t\r\n"));
+    line.erase(line.find_last_not_of(" \t\r\n") + 1);
+
+    if (line.empty() || line[0] == ';' || line[0] == '#') {
+      continue;  // Skip comments/blank lines
+    }
+
+    if (line.front() == '[' && line.back() == ']') {
+      current_section = line.substr(1, line.size() - 2);
+      continue;
+    }
+
+    auto pos = line.find('=');
+    if (pos == std::string::npos)
+      pos = line.find(':');
+    if (pos == std::string::npos)
+      continue;  // Invalid line
+
+    std::string key = line.substr(0, pos);
+    std::string value = line.substr(pos + 1);
+    // Trim
+    key.erase(0, key.find_first_not_of(" \t"));
+    key.erase(key.find_last_not_of(" \t") + 1);
+    value.erase(0, value.find_first_not_of(" \t"));
+    value.erase(value.find_last_not_of(" \t") + 1);
+
+    data_[current_section][key] = value;
+  }
+  return true;
+}
+
+bool ini_config_t::has(const std::string& section, const std::string& key) const
+{
+  auto sec_it = data_.find(section);
+  if (sec_it == data_.end())
+    return false;
+  return sec_it->second.find(key) != sec_it->second.end();
+}
+
+std::string ini_config_t::get_string(const std::string& section,
+                                    const std::string& key,
+                                    const std::string& default_value) const
+{
+  auto sec_it = data_.find(section);
+  if (sec_it == data_.end())
+    return default_value;
+  auto key_it = sec_it->second.find(key);
+  if (key_it == sec_it->second.end())
+    return default_value;
+  return key_it->second;
+}
+}  // namespace toolbox::utils

--- a/src/include/cpp-toolbox/utils/click.hpp
+++ b/src/include/cpp-toolbox/utils/click.hpp
@@ -10,6 +10,8 @@
 namespace toolbox::utils
 {
 
+class ini_config_t;
+
 class CPP_TOOLBOX_EXPORT parameter_t
 {
 protected:
@@ -146,6 +148,9 @@ public:
 
   int parse_and_execute(const std::vector<std::string>& args);
   std::string format_help() const;
+
+  void apply_ini_config(const class ini_config_t& config,
+                        const std::string& section = "");
 
 private:
   void add_help();

--- a/src/include/cpp-toolbox/utils/impl/click_impl.hpp
+++ b/src/include/cpp-toolbox/utils/impl/click_impl.hpp
@@ -9,6 +9,7 @@
 
 #include <cpp-toolbox/logger/thread_logger.hpp>
 #include <cpp-toolbox/utils/click.hpp>
+#include <cpp-toolbox/utils/ini_config.hpp>
 
 namespace toolbox::utils::impl
 {
@@ -462,6 +463,24 @@ argument_t<T>& command_t::add_argument(const std::string& name,
   argument_t<T>* argument_ptr = argument.get();
   parameters_.push_back(std::move(argument));
   return *argument_ptr;
+}
+
+inline void command_t::apply_ini_config(const ini_config_t& config,
+                                        const std::string& section)
+{
+  std::string current_section = section.empty() ? name_ : section;
+  for (const auto& param_ptr : parameters_) {
+    if (param_ptr->is_option()) {
+      const std::string key = param_ptr->get_name();
+      if (config.has(current_section, key)) {
+        param_ptr->parse(config.get_string(current_section, key));
+      }
+    }
+  }
+
+  for (const auto& cmd : subcommands_) {
+    cmd->apply_ini_config(config, current_section + "." + cmd->get_name());
+  }
 }
 
 }  // namespace toolbox::utils

--- a/src/include/cpp-toolbox/utils/ini_config.hpp
+++ b/src/include/cpp-toolbox/utils/ini_config.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <cpp-toolbox/cpp-toolbox_export.hpp>
+
+namespace toolbox::utils
+{
+class CPP_TOOLBOX_EXPORT ini_config_t
+{
+public:
+  bool load(const std::string& file_path);
+  bool has(const std::string& section, const std::string& key) const;
+  std::string get_string(const std::string& section,
+                         const std::string& key,
+                         const std::string& default_value = "") const;
+
+private:
+  using section_map_t =
+      std::unordered_map<std::string, std::unordered_map<std::string, std::string>>;
+  section_map_t data_;
+};
+}  // namespace toolbox::utils

--- a/src/include/cpp-toolbox/utils/ini_struct.hpp
+++ b/src/include/cpp-toolbox/utils/ini_struct.hpp
@@ -1,0 +1,215 @@
+#pragma once
+
+#include <optional>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+
+#include <cpp-toolbox/logger/thread_logger.hpp>
+#include <cpp-toolbox/utils/ini_config.hpp>
+
+namespace toolbox::utils
+{
+namespace ini_detail
+{
+// Trait to detect std::optional
+template<typename T>
+struct is_optional : std::false_type
+{
+};
+
+template<typename U>
+struct is_optional<std::optional<U>> : std::true_type
+{
+};
+
+template<typename T>
+inline constexpr bool is_optional_v =
+    is_optional<std::remove_cv_t<std::remove_reference_t<T>>>::value;
+
+template<typename T>
+struct optional_value_type
+{
+};
+
+template<typename U>
+struct optional_value_type<std::optional<U>>
+{
+  using type = U;
+};
+
+template<typename T>
+using optional_value_type_t = typename optional_value_type<
+    std::remove_cv_t<std::remove_reference_t<T>>>::type;
+
+// Trait to detect if a type can be streamed from an istream
+template<typename T, typename = void>
+struct has_istream_operator : std::false_type
+{
+};
+
+template<typename T>
+struct has_istream_operator<
+    T,
+    std::void_t<decltype(std::declval<std::istream&>() >> std::declval<T&>())>>
+    : std::true_type
+{
+};
+
+template<typename T>
+inline constexpr bool has_istream_operator_v =
+    has_istream_operator<std::remove_cv_t<std::remove_reference_t<T>>>::value;
+
+// Parsing helpers ---------------------------------------------------------
+
+template<typename T>
+bool parse_non_optional(const std::string& input, T& output)
+{
+  std::stringstream ss(input);
+  if constexpr (std::is_same_v<T, bool>) {
+    std::string lower_input;
+    std::transform(input.begin(),
+                   input.end(),
+                   std::back_inserter(lower_input),
+                   ::tolower);
+    if (lower_input == "true" || lower_input == "1") {
+      output = true;
+      return true;
+    } else if (lower_input == "false" || lower_input == "0") {
+      output = false;
+      return true;
+    } else {
+      return false;
+    }
+  } else if constexpr (std::is_integral_v<T>) {
+    if (input.size() > 2 && input[0] == '0'
+        && (input[1] == 'x' || input[1] == 'X'))
+    {
+      ss >> std::hex >> output;
+    } else {
+      ss >> output;
+    }
+    return ss.eof() && !ss.fail();
+  } else if constexpr (std::is_floating_point_v<T>) {
+    ss >> output;
+    return ss.eof() && !ss.fail();
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    output = input;
+    return true;
+  } else {
+    if constexpr (has_istream_operator_v<T>) {
+      ss >> output;
+      return ss.eof() && !ss.fail();
+    } else {
+      LOG_WARN_S << "Unsupported type for INI parser: " << typeid(T).name();
+      return false;
+    }
+  }
+}
+
+template<typename T_Optional>
+bool parse_non_optional(const std::string& input, std::optional<T_Optional>& output)
+{
+  T_Optional value;
+  if (parse_non_optional(input, value)) {
+    output = value;
+    return true;
+  }
+  output = std::nullopt;
+  return false;
+}
+
+template<typename T>
+bool parse_value(const std::string& input, T& output)
+{
+  if constexpr (is_optional_v<T>) {
+    if (input.empty()) {
+      output = std::nullopt;
+      return true;
+    }
+    using value_type = optional_value_type_t<T>;
+    value_type parsed;
+    bool ok = parse_non_optional(input, parsed);
+    if (ok)
+      output = parsed;
+    else
+      output = std::nullopt;
+    return ok;
+  } else {
+    return parse_non_optional(input, output);
+  }
+}
+
+}  // namespace ini_detail
+
+// Field descriptor -------------------------------------------------------
+
+template<typename Struct, typename Member>
+struct ini_field_desc
+{
+  const char* section;
+  const char* key;
+  Member Struct::*member;
+};
+
+// Trait to associate a struct with field descriptors
+template<typename T>
+struct ini_struct_traits
+{
+  static constexpr auto fields = std::make_tuple();
+};
+
+// Load struct from ini_config_t -----------------------------------------
+
+template<typename Struct>
+bool load_struct_from_ini(const ini_config_t& cfg,
+                          Struct& obj,
+                          const std::string& base_section = "")
+{
+  bool success = true;
+  constexpr auto fields = ini_struct_traits<Struct>::fields;
+  std::apply(
+      [&](auto&&... field)
+      {
+        ([&]() {
+          using member_t = std::remove_reference_t<decltype(obj.*(field.member))>;
+          std::string section = base_section;
+          if (field.section && field.section[0] != '\0') {
+            if (!base_section.empty()) {
+              section += ".";
+              section += field.section;
+            } else {
+              section = field.section;
+            }
+          }
+
+          if (cfg.has(section, field.key)) {
+            member_t value{};
+            if (ini_detail::parse_value(cfg.get_string(section, field.key),
+                                       value))
+            {
+              obj.*(field.member) = value;
+            } else {
+              success = false;
+            }
+          }
+        }(), ...);
+      },
+      fields);
+  return success;
+}
+
+}  // namespace toolbox::utils
+
+// Helper macros to declare reflection metadata -------------------------
+
+#define TOOLBOX_INI_FIELD(struct_type, member, section, key) \
+  toolbox::utils::ini_field_desc<struct_type, decltype(struct_type::member)>{ \
+      section, key, &struct_type::member }
+
+#define TOOLBOX_INI_STRUCT(struct_type, ...) \
+  template<> struct toolbox::utils::ini_struct_traits<struct_type> { \
+    static constexpr auto fields = std::make_tuple(__VA_ARGS__); \
+  };
+

--- a/test/data/sample.ini
+++ b/test/data/sample.ini
@@ -1,0 +1,3 @@
+[section1]
+key1=value1
+key2=42

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(BASE_TEST_FILES 
+set(BASE_TEST_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/timer_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/click_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/random_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ini_config_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ini_struct_test.cpp
 )
 
 list(APPEND TEST_FILES ${BASE_TEST_FILES})

--- a/test/utils/ini_config_test.cpp
+++ b/test/utils/ini_config_test.cpp
@@ -1,0 +1,16 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cpp-toolbox/utils/ini_config.hpp>
+#include <filesystem>
+#include "test_data_dir.hpp"
+
+using namespace toolbox::utils;
+
+TEST_CASE("INI config basic load", "[ini]")
+{
+  ini_config_t cfg;
+  bool loaded = cfg.load(std::filesystem::path(test_data_dir) / "sample.ini");
+  REQUIRE(loaded);
+  REQUIRE(cfg.has("section1", "key1"));
+  REQUIRE(cfg.get_string("section1", "key1") == "value1");
+}

--- a/test/utils/ini_struct_test.cpp
+++ b/test/utils/ini_struct_test.cpp
@@ -1,0 +1,27 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cpp-toolbox/utils/ini_config.hpp>
+#include <cpp-toolbox/utils/ini_struct.hpp>
+#include <filesystem>
+#include "test_data_dir.hpp"
+
+using namespace toolbox::utils;
+
+struct demo_config
+{
+  std::string key1;
+  int key2 = 0;
+};
+
+TOOLBOX_INI_STRUCT(demo_config,
+    TOOLBOX_INI_FIELD(demo_config, key1, "section1", "key1"),
+    TOOLBOX_INI_FIELD(demo_config, key2, "section1", "key2"))
+
+TEST_CASE("INI struct reflection load", "[ini_struct]")
+{
+  ini_config_t cfg;
+  REQUIRE(cfg.load(std::filesystem::path(test_data_dir) / "sample.ini"));
+  demo_config dc{};
+  REQUIRE(load_struct_from_ini(cfg, dc));
+  REQUIRE(dc.key1 == "value1");
+  REQUIRE(dc.key2 == 42);
+}


### PR DESCRIPTION
## Summary
- implement simple reflection macros for loading structs from INI files
- update click example to show struct reflection usage
- expand sample INI and add new ini_struct tests

## Testing
- `make build` *(fails: interrupted)*
- `make test` *(fails: test binary missing)*