### PR TITLE
Fix click example INI config usage

### DIFF
--- a/docs/md/click_example.md
+++ b/docs/md/click_example.md
@@ -18,9 +18,9 @@ The example looks for `example/example.ini`. A minimal configuration:
 ```ini
 [example_cli]
 verbose=true
-config=config.json
 
 [example_cli.process]
+input_file=input.dat
 output=output.dat
 count=5
 threshold=0.7
@@ -43,3 +43,17 @@ build/bin/example_click process input.dat -n 10
 ```
 
 Options may also come from the INI file.
+
+## Using INI configuration
+
+The application loads `example/example.ini` by default. You can specify an
+alternative file with `--ini <file>`. Values from the file populate both options
+and arguments after the CLI is set up. Command line input still overrides the
+file. If `apply_ini_config` is called before options are added, the values will
+not be applied.
+
+Example using only the configuration values:
+
+```sh
+build/bin/example_click process --ini example/example.ini
+```

--- a/example/example.ini
+++ b/example/example.ini
@@ -1,8 +1,8 @@
 [example_cli]
 verbose=false
-config=config.json
 
 [example_cli.process]
+input_file=input.dat
 output=output.dat
 count=5
 threshold=0.7

--- a/src/include/cpp-toolbox/utils/impl/click_impl.hpp
+++ b/src/include/cpp-toolbox/utils/impl/click_impl.hpp
@@ -470,11 +470,9 @@ inline void command_t::apply_ini_config(const ini_config_t& config,
 {
   std::string current_section = section.empty() ? name_ : section;
   for (const auto& param_ptr : parameters_) {
-    if (param_ptr->is_option()) {
-      const std::string key = param_ptr->get_name();
-      if (config.has(current_section, key)) {
-        param_ptr->parse(config.get_string(current_section, key));
-      }
+    const std::string key = param_ptr->get_name();
+    if (config.has(current_section, key)) {
+      param_ptr->parse(config.get_string(current_section, key));
     }
   }
 


### PR DESCRIPTION
## Summary
- allow ini files to populate required arguments
- pre-scan for `--ini` flag in the click example
- document new ini configuration usage

## Testing
- `cmake --build build --target example_click`
- `cmake --build build --target cpp-toolbox_test`
- `ctest --test-dir build`
