### PR TITLE
Improve table output and add simple ASCII plotting

### DIFF
--- a/example/plot_example.cpp
+++ b/example/plot_example.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+#include <vector>
+
+#include "cpp-toolbox/utils/plot.hpp"
+
+int main() {
+  using namespace toolbox::utils;
+
+  plot_t plot;
+  std::vector<double> xs1{0, 1, 2, 3, 4};
+  std::vector<double> ys1{1, 3, 2, 4, 3};
+  plot.add_line_series(xs1, ys1, color_t::GREEN, '*');
+
+  std::vector<double> xs2{0.5, 1.5, 2.5, 3.5};
+  std::vector<double> ys2{1.5, 2.0, 3.0, 2.5};
+  plot.add_scatter_series(xs2, ys2, color_t::RED, 'o');
+
+  std::cout << plot.render(40, 10) << "\n";
+  return 0;
+}

--- a/example/print_example.cpp
+++ b/example/print_example.cpp
@@ -20,7 +20,7 @@ int main()
 
   // --- 示例 1: 基本表格与对齐 / Basic table and alignment ---
   std::cout << "--- Example 1: Basic Table and Alignment ---" << "\n";
-  table_t t1;
+  table_t t1(get_rounded_style());
   t1.set_headers({"Name", "Age", "City"})
       .add_row("Alice", 30, "New York")
       .add_row("Bob", 24, "Los Angeles")
@@ -85,9 +85,9 @@ int main()
   // --- 示例 6: 写入文件，无颜色 / File output without ANSI colors ---
   std::cout << "--- Example 6: File Output (no colors) ---" << "\n";
   table_t t6 = t4;  // 复用之前的 t4
-  t6.set_file_output_color(false);
+  std::string plain = t6.to_string(false);
   std::ofstream ofs("table_output.txt");
-  ofs << t6;
+  ofs << plain;
   ofs.close();
   std::cout << "Written to table_output.txt" << "\n";
 
@@ -139,7 +139,7 @@ int main()
   print_style_t custom_style;
   custom_style.border_h = "=";
   custom_style.border_v = "*";
-  custom_style.corner = "#";
+  custom_style.box.center = "#";
   custom_style.padding = "";  // 无填充 (No padding)
   custom_style.show_header = false;
   custom_style.alignment = align_t::CENTER;

--- a/src/impl/cpp-toolbox/CMakeLists.txt
+++ b/src/impl/cpp-toolbox/CMakeLists.txt
@@ -20,6 +20,7 @@ set(cpp-toolbox_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/types/point.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/click.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/print.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/plot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/random.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/ini_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/io/pcd.cpp

--- a/src/impl/cpp-toolbox/utils/plot.cpp
+++ b/src/impl/cpp-toolbox/utils/plot.cpp
@@ -1,0 +1,127 @@
+#include "cpp-toolbox/utils/plot.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+namespace toolbox::utils {
+
+void plot_t::add_line_series(const std::vector<double>& xs,
+                             const std::vector<double>& ys,
+                             color_t color,
+                             char symbol)
+{
+  m_series.push_back(series_t{xs, ys, color, true, symbol});
+}
+
+void plot_t::add_scatter_series(const std::vector<double>& xs,
+                                const std::vector<double>& ys,
+                                color_t color,
+                                char symbol)
+{
+  m_series.push_back(series_t{xs, ys, color, false, symbol});
+}
+
+std::string plot_t::render(size_t width, size_t height) const
+{
+  if (m_series.empty() || width == 0 || height == 0)
+    return "";
+
+  double min_x = std::numeric_limits<double>::max();
+  double max_x = std::numeric_limits<double>::lowest();
+  double min_y = min_x;
+  double max_y = max_x;
+
+  for (const auto& s : m_series) {
+    for (double v : s.xs) {
+      min_x = std::min(min_x, v);
+      max_x = std::max(max_x, v);
+    }
+    for (double v : s.ys) {
+      min_y = std::min(min_y, v);
+      max_y = std::max(max_y, v);
+    }
+  }
+  if (min_x == max_x) {
+    min_x -= 1.0;
+    max_x += 1.0;
+  }
+  if (min_y == max_y) {
+    min_y -= 1.0;
+    max_y += 1.0;
+  }
+
+  std::vector<std::string> grid(height, std::string(width, ' '));
+  std::vector<std::vector<color_t>> colors(height, std::vector<color_t>(width, color_t::DEFAULT));
+
+  auto map_x = [&](double x) {
+    return static_cast<int>((x - min_x) / (max_x - min_x) * (static_cast<double>(width - 1))); };
+  auto map_y = [&](double y) {
+    return static_cast<int>((y - min_y) / (max_y - min_y) * (static_cast<double>(height - 1))); };
+
+  for (const auto& s : m_series) {
+    size_t n = std::min(s.xs.size(), s.ys.size());
+    if (n == 0) continue;
+    int prev_x = map_x(s.xs[0]);
+    int prev_y = map_y(s.ys[0]);
+    for (size_t i = 0; i < n; ++i) {
+      int gx = map_x(s.xs[i]);
+      int gy = map_y(s.ys[i]);
+      size_t row = height - 1 - static_cast<size_t>(gy);
+      size_t col = static_cast<size_t>(gx);
+      if (row < height && col < width) {
+        grid[row][col] = s.symbol;
+        colors[row][col] = s.color;
+      }
+      if (s.line && i > 0) {
+        int x0 = prev_x;
+        int y0 = prev_y;
+        int x1 = gx;
+        int y1 = gy;
+        int dx = std::abs(x1 - x0);
+        int dy = -std::abs(y1 - y0);
+        int sx = x0 < x1 ? 1 : -1;
+        int sy = y0 < y1 ? 1 : -1;
+        int err = dx + dy;
+        while (true) {
+          size_t r = height - 1 - static_cast<size_t>(y0);
+          size_t c = static_cast<size_t>(x0);
+          if (r < height && c < width) {
+            grid[r][c] = s.symbol;
+            colors[r][c] = s.color;
+          }
+          if (x0 == x1 && y0 == y1)
+            break;
+          int e2 = 2 * err;
+          if (e2 >= dy) {
+            err += dy;
+            x0 += sx;
+          }
+          if (e2 <= dx) {
+            err += dx;
+            y0 += sy;
+          }
+        }
+      }
+      prev_x = gx;
+      prev_y = gy;
+    }
+  }
+
+  std::ostringstream oss;
+  for (size_t r = 0; r < height; ++r) {
+    for (size_t c = 0; c < width; ++c) {
+      std::string ch(1, grid[r][c]);
+      if (colors[r][c] != color_t::DEFAULT) {
+        oss << color_handler_t::colorize(ch, colors[r][c], color_t::DEFAULT);
+      } else {
+        oss << ch;
+      }
+    }
+    if (r + 1 < height)
+      oss << '\n';
+  }
+  return oss.str();
+}
+
+} // namespace toolbox::utils

--- a/src/include/cpp-toolbox/utils/plot.hpp
+++ b/src/include/cpp-toolbox/utils/plot.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "cpp-toolbox/utils/print.hpp"
+
+namespace toolbox::utils {
+
+class CPP_TOOLBOX_EXPORT plot_t {
+public:
+  struct series_t {
+    std::vector<double> xs;
+    std::vector<double> ys;
+    color_t color{color_t::DEFAULT};
+    bool line{true};
+    char symbol{'*'};
+  };
+
+  /** 添加折线数据 / Add line series */
+  void add_line_series(const std::vector<double>& xs,
+                       const std::vector<double>& ys,
+                       color_t color = color_t::DEFAULT,
+                       char symbol = '*');
+  /** 添加散点数据 / Add scatter series */
+  void add_scatter_series(const std::vector<double>& xs,
+                          const std::vector<double>& ys,
+                          color_t color = color_t::DEFAULT,
+                          char symbol = 'o');
+
+  /** 渲染为字符串 / Render as string */
+  [[nodiscard]] std::string render(size_t width = 60, size_t height = 20) const;
+
+private:
+  std::vector<series_t> m_series;
+};
+
+} // namespace toolbox::utils

--- a/src/include/cpp-toolbox/utils/print.hpp
+++ b/src/include/cpp-toolbox/utils/print.hpp
@@ -70,9 +70,21 @@ enum class CPP_TOOLBOX_EXPORT color_t : std::uint8_t
  */
 struct CPP_TOOLBOX_EXPORT print_style_t
 {
+  struct box_chars_t
+  {
+    std::string top_left = "+";
+    std::string top_right = "+";
+    std::string bottom_left = "+";
+    std::string bottom_right = "+";
+    std::string left_joint = "+";
+    std::string right_joint = "+";
+    std::string top_joint = "+";
+    std::string bottom_joint = "+";
+    std::string center = "+";
+  } box;
+
   std::string border_h = "-";  ///< 水平边框字符/Horizontal border character
   std::string border_v = "|";  ///< 垂直边框字符/Vertical border character
-  std::string corner = "+";  ///< 角字符/Corner character
   std::string padding = " ";  ///< 单元格填充/Cell padding
   bool show_header = true;  ///< 是否显示表头/Show header or not
   bool show_border = true;  ///< 是否显示边框/Show border or not
@@ -96,6 +108,29 @@ struct CPP_TOOLBOX_EXPORT print_style_t
 inline auto get_default_style() -> const print_style_t&
 {
   static const print_style_t style = print_style_t();
+  return style;
+}
+
+/**
+ * @brief 获取圆角边框风格/Style using Unicode box drawing characters
+ */
+inline auto get_rounded_style() -> const print_style_t&
+{
+  static const print_style_t style = [] {
+    print_style_t s;
+    s.border_h = "\xE2\x94\x80";      // "─"
+    s.border_v = "\xE2\x94\x82";      // "│"
+    s.box.top_left = "\xE2\x94\x8C";      // "┌"
+    s.box.top_right = "\xE2\x94\x90";     // "┐"
+    s.box.bottom_left = "\xE2\x94\x94";   // "└"
+    s.box.bottom_right = "\xE2\x94\x98";  // "┘"
+    s.box.left_joint = "\xE2\x94\x9C";    // "├"
+    s.box.right_joint = "\xE2\x94\xA4";   // "┤"
+    s.box.top_joint = "\xE2\x94\xAC";     // "┬"
+    s.box.bottom_joint = "\xE2\x94\xB4";  // "┴"
+    s.box.center = "\xE2\x94\xBC";       // "┼"
+    return s;
+  }();
   return style;
 }
 
@@ -553,6 +588,13 @@ public:
   table_t& set_file_output_color(bool enable);
 
   /**
+   * @brief 将表格渲染为字符串 / Render table as a string
+   * @param with_color 是否保留ANSI颜色 / true to keep ANSI colors
+   * @return std::string 渲染后的表格 / Rendered table string
+   */
+  [[nodiscard]] auto to_string(bool with_color = true) const -> std::string;
+
+  /**
    * @brief 打印表格 / Stream operator for printing table_t
    * @param os 输出流 / Output stream
    * @param tbl 要打印的table_t对象 / Table object to print
@@ -628,7 +670,14 @@ private:
    * @brief 打印水平边框 / Print horizontal border line
    * @param os 输出流 / Output stream
    */
-  void print_horizontal_border(std::ostream& os) const;
+  enum class border_pos_t
+  {
+    TOP,
+    MIDDLE,
+    BOTTOM
+  };
+
+  void print_horizontal_border(std::ostream& os, border_pos_t pos) const;
 
   /**
    * @brief 打印单行（支持换行/截断及合并） / Print a logical row with


### PR DESCRIPTION
## Summary
- allow `table_t` to render to a string with optional ANSI colors
- add `plot_t` for rudimentary line and scatter charts
- install new plot sources and example
- update example to demonstrate saving a colorless table

## Testing
- `cmake -S . -B build -DBUILD_EXAMPLES=ON`
- `cmake --build build --target example_print example_plot`
- `./build/bin/example_print > /tmp/print_out.txt`
- `./build/bin/example_plot > /tmp/plot_out.txt`
- `ctest --test-dir build`