### PR TITLE
Add parallel TimSort with benchmarks

### DIFF
--- a/benchmark/concurrent/parallel_benc.cpp
+++ b/benchmark/concurrent/parallel_benc.cpp
@@ -1,12 +1,15 @@
 #include <algorithm>  // For std::for_each, std::transform
 // #include <execution>  // For std::execution::par (requires C++17 and
 // potentially TBB)
+#include <chrono>
 #include <iostream>  // For potential error output
 #include <numeric>  // For std::accumulate, std::iota
 #include <vector>
 
 #include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_test_macros.hpp>
+
+#include "cpp-toolbox/utils/plot.hpp"
 
 // Include your parallel header
 #include <cpp-toolbox/concurrent/parallel.hpp>  // Corrected include path
@@ -77,6 +80,60 @@ TEST_CASE("Benchmark Parallel Algorithms")
   std::iota(data.begin(), data.end(), 1);  // Fill with 1, 2, 3, ...
 
   std::vector<int> output_data(data_size);  // For transform output
+  std::vector<long long> scan_output(data_size);  // For inclusive scan
+
+  // --- Correctness checks -------------------------------------------------
+  SECTION("Correctness")
+  {
+    long long expected_sum = serial_sum(data);
+    REQUIRE(toolbox_parallel_sum(data) == expected_sum);
+
+    std::vector<int> expected_for_each = data;
+    std::for_each(
+        expected_for_each.begin(), expected_for_each.end(), square_in_place_op);
+    std::vector<int> parallel_for_each_vec = data;
+    toolbox::concurrent::parallel_for_each(parallel_for_each_vec.begin(),
+                                           parallel_for_each_vec.end(),
+                                           square_in_place_op);
+    REQUIRE(parallel_for_each_vec == expected_for_each);
+
+    std::vector<int> expected_transform(data_size);
+    std::transform(
+        data.cbegin(), data.cend(), expected_transform.begin(), square_op);
+    std::vector<int> parallel_transform_out(data_size);
+    toolbox::concurrent::parallel_transform(
+        data.cbegin(), data.cend(), parallel_transform_out.begin(), square_op);
+    REQUIRE(parallel_transform_out == expected_transform);
+
+    std::vector<long long> expected_scan(data_size);
+    std::inclusive_scan(data.cbegin(),
+                        data.cend(),
+                        expected_scan.begin(),
+                        std::plus<long long>(),
+                        0LL);
+    std::vector<long long> parallel_scan_out(data_size);
+    toolbox::concurrent::parallel_inclusive_scan(data.cbegin(),
+                                                 data.cend(),
+                                                 parallel_scan_out.begin(),
+                                                 0LL,
+                                                 std::plus<long long>(),
+                                                 0LL);
+    REQUIRE(parallel_scan_out == expected_scan);
+
+    std::vector<int> expected_sort = data;
+    std::sort(expected_sort.begin(), expected_sort.end());
+    std::vector<int> parallel_sort = data;
+    toolbox::concurrent::parallel_merge_sort(parallel_sort.begin(),
+                                             parallel_sort.end());
+    REQUIRE(parallel_sort == expected_sort);
+
+    std::vector<int> expected_tim = data;
+    std::stable_sort(expected_tim.begin(), expected_tim.end());
+    std::vector<int> tim_sorted = data;
+    toolbox::concurrent::parallel_tim_sort(tim_sorted.begin(),
+                                           tim_sorted.end());
+    REQUIRE(tim_sorted == expected_tim);
+  }
 
   // --- Benchmark Reduction (Summation) ---
   SECTION("Reduction Benchmarks")
@@ -104,6 +161,27 @@ TEST_CASE("Benchmark Parallel Algorithms")
     BENCHMARK("Parallel Sum (toolbox::parallel_reduce)")
     {
       return toolbox_parallel_sum(data);
+    };
+  }
+
+  // --- Benchmark Inclusive Scan ---
+  SECTION("Inclusive Scan Benchmarks")
+  {
+    BENCHMARK("Serial Inclusive Scan (std::inclusive_scan)")
+    {
+      std::inclusive_scan(data.begin(), data.end(), scan_output.begin());
+      return scan_output.back();
+    };
+
+    BENCHMARK("Parallel Inclusive Scan (toolbox::parallel_inclusive_scan)")
+    {
+      toolbox::concurrent::parallel_inclusive_scan(data.begin(),
+                                                   data.end(),
+                                                   scan_output.begin(),
+                                                   0LL,
+                                                   std::plus<long long>(),
+                                                   0LL);
+      return scan_output.back();
     };
   }
 
@@ -202,6 +280,103 @@ TEST_CASE("Benchmark Parallel Algorithms")
       // benchmark is tricky
       return output_data.back();  // Return something to prevent optimization
     };
+  }
+
+  // --- Benchmark Merge Sort ---
+  SECTION("Merge Sort Benchmarks")
+  {
+    std::vector<int> sort_tmp;
+
+    BENCHMARK_ADVANCED("Serial Sort (std::sort)")(
+        Catch::Benchmark::Chronometer meter)
+    {
+      meter.measure(
+          [&]()
+          {
+            sort_tmp = data;
+            std::sort(sort_tmp.begin(), sort_tmp.end());
+            return sort_tmp.back();
+          });
+    };
+
+    BENCHMARK_ADVANCED("Parallel Merge Sort (toolbox::parallel_merge_sort)")(
+        Catch::Benchmark::Chronometer meter)
+    {
+      meter.measure(
+          [&]()
+          {
+            sort_tmp = data;
+            toolbox::concurrent::parallel_merge_sort(sort_tmp.begin(),
+                                                     sort_tmp.end());
+            return sort_tmp.back();
+          });
+    };
+  }
+
+  // --- Benchmark Tim Sort ---
+  SECTION("Tim Sort Benchmarks")
+  {
+    std::vector<int> sort_tmp;
+
+    BENCHMARK_ADVANCED("Serial Stable Sort (std::stable_sort)")(
+        Catch::Benchmark::Chronometer meter)
+    {
+      meter.measure(
+          [&]()
+          {
+            sort_tmp = data;
+            std::stable_sort(sort_tmp.begin(), sort_tmp.end());
+            return sort_tmp.back();
+          });
+    };
+
+    BENCHMARK_ADVANCED("Parallel Tim Sort (toolbox::parallel_tim_sort)")(
+        Catch::Benchmark::Chronometer meter)
+    {
+      meter.measure(
+          [&]()
+          {
+            sort_tmp = data;
+            toolbox::concurrent::parallel_tim_sort(sort_tmp.begin(),
+                                                   sort_tmp.end());
+            return sort_tmp.back();
+          });
+    };
+  }
+
+  // --- Simple Timing Plot -------------------------------------------------
+  SECTION("Timing Plot")
+  {
+    using namespace std::chrono;
+    auto measure = [&](auto&& func)
+    {
+      const int iters = 3;
+      double total = 0.0;
+      for (int i = 0; i < iters; ++i) {
+        auto start = high_resolution_clock::now();
+        func();
+        auto end = high_resolution_clock::now();
+        total += duration<double>(end - start).count();
+      }
+      return total / static_cast<double>(iters);
+    };
+
+    double t_serial = measure([&]() { serial_sum(data); });
+    double t_parallel = measure([&]() { toolbox_parallel_sum(data); });
+
+    toolbox::utils::plot_t plot;
+    plot.set_title("Sum Benchmark (sec)");
+    plot.set_x_axis();
+    plot.set_y_axis();
+    plot.enable_axis_grid();
+    plot.add_scatter_series({1.0, 2.0},
+                            {t_serial, t_parallel},
+                            toolbox::utils::color_t::GREEN,
+                            toolbox::utils::plot_t::style_t::CROSS);
+    std::cout << plot.render(40, 10) << "\n";
+
+    REQUIRE(t_serial > 0.0);
+    REQUIRE(t_parallel > 0.0);
   }
 }
 

--- a/test/concurrent/parallel_test.cpp
+++ b/test/concurrent/parallel_test.cpp
@@ -395,3 +395,21 @@ TEST_CASE("Parallel Merge Sort Tests", "[concurrent][parallel_merge_sort]")
     REQUIRE_THAT(data, Equals(expected));
   }
 }
+
+TEST_CASE("Parallel Tim Sort Tests", "[concurrent][parallel_tim_sort]")
+{
+  SECTION("Sort random integers stably")
+  {
+    std::mt19937 rng(43);
+    std::uniform_int_distribution<int> dist(0, 1000000);
+    std::vector<int> data(20000);
+    for (auto& v : data) {
+      v = dist(rng);
+    }
+    std::vector<int> expected = data;
+    std::stable_sort(expected.begin(), expected.end());
+
+    parallel_tim_sort(data.begin(), data.end());
+    REQUIRE_THAT(data, Equals(expected));
+  }
+}


### PR DESCRIPTION
## Summary
- implement `parallel_tim_sort`
- expand benchmark correctness to cover inclusive scan and sorting
- add benchmark sections for inclusive scan, merge sort, and TimSort
- test TimSort correctness

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DBUILD_BENCHMARKS=ON`
- `cmake --build build -j $(nproc)`
- `build/bin/cpp-toolbox_benchmark "Benchmark Parallel Algorithms"`
- `build/bin/cpp-toolbox_test "Parallel Tim Sort Tests"`
