### PR TITLE
Fix Windows path conversions

### DIFF
--- a/src/impl/cpp-toolbox/file/file.cpp
+++ b/src/impl/cpp-toolbox/file/file.cpp
@@ -31,7 +31,12 @@ auto string_to_path(const std::string& str) -> std::filesystem::path
 
 auto path_to_string(const std::filesystem::path& path) -> std::string
 {
+#if defined(CPP_TOOLBOX_PLATFORM_WINDOWS)
+  auto u8 = path.u8string();
+  return std::string(u8.begin(), u8.end());
+#else
   return path.string();
+#endif
 }
 
 auto get_current_working_directory() -> std::filesystem::path

--- a/src/impl/cpp-toolbox/io/kitti_pcd.cpp
+++ b/src/impl/cpp-toolbox/io/kitti_pcd.cpp
@@ -29,7 +29,8 @@ kitti_pcd_dataset_t::at_impl(std::size_t index) const
     return std::nullopt;
   }
 
-  auto cloud = read_kitti_bin<float>(m_binary_paths[index]);
+  auto cloud = read_kitti_bin<float>(
+      toolbox::file::path_to_string(m_binary_paths[index]));
   return cloud;
 }
 
@@ -59,8 +60,10 @@ kitti_pcd_pair_t::at_impl(std::size_t index) const
     return std::nullopt;
   }
 
-  auto cloud1 = read_kitti_bin<float>(m_binary_paths[index]);
-  auto cloud2 = read_kitti_bin<float>(m_binary_paths[index + m_skip]);
+  auto cloud1 =
+      read_kitti_bin<float>(toolbox::file::path_to_string(m_binary_paths[index]));
+  auto cloud2 = read_kitti_bin<float>(
+      toolbox::file::path_to_string(m_binary_paths[index + m_skip]));
   return std::make_pair(std::move(cloud1), std::move(cloud2));
 }
 


### PR DESCRIPTION
## Summary
- handle Windows UTF-8 path conversion in `path_to_string`
- use `path_to_string` when loading KITTI point clouds

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)`
- `ctest --test-dir build --output-on-failure`
