### PR TITLE
Add table title and footer example

### DIFF
--- a/example/print_example.cpp
+++ b/example/print_example.cpp
@@ -18,8 +18,8 @@ int main()
 {
   using namespace toolbox::utils;
 
-  // --- 示例 1: 基本表格与对齐 / Basic table and alignment ---
-  std::cout << "--- Example 1: Basic Table and Alignment ---" << "\n";
+  // --- 示例 1: 基本表格、标题与尾部 / Basic table with title and footer ---
+  std::cout << "--- Example 1: Basic Table with Title and Footer ---" << "\n";
 
 #ifdef CPP_TOOLBOX_PLATFORM_WINDOWS
   // 在 Windows 上使用 ASCII 风格
@@ -33,6 +33,8 @@ int main()
       .add_row("Alice", 30, "New York")
       .add_row("Bob", 24, "Los Angeles")
       .add_row("Charlie", 35, "Chicago");
+  // 设置表格标题和尾部 / Set table title and footer
+  t1.set_title("Employee List").set_footer("End of List");
   // 第二列右对齐 / Right-align second column
   t1.set_column_align(1, align_t::RIGHT);
   std::cout << t1 << "\n";

--- a/src/impl/cpp-toolbox/utils/print.cpp
+++ b/src/impl/cpp-toolbox/utils/print.cpp
@@ -94,6 +94,8 @@ table_t::table_t(const print_style_t& style)
     , m_highlight_cb(nullptr)
     , m_out_color(true)
     , m_file_color(false)
+    , m_title()
+    , m_footer()
 {
 }
 
@@ -108,6 +110,20 @@ table_t& table_t::set_headers(const std::vector<std::string>& hdrs)
 table_t& table_t::add_row(const std::vector<std::string>& row)
 {
   m_data.push_back(row);
+  return *this;
+}
+
+/** @brief 设置表格标题 / Set table title */
+table_t& table_t::set_title(const std::string& title)
+{
+  m_title = title;
+  return *this;
+}
+
+/** @brief 设置表格尾部文本 / Set table footer */
+table_t& table_t::set_footer(const std::string& footer)
+{
+  m_footer = footer;
   return *this;
 }
 
@@ -418,6 +434,9 @@ std::ostream& operator<<(std::ostream& os, const table_t& tbl)
   if (tbl.m_headers.empty()) {
     return os << "[Empty table]\n";
   }
+  if (!tbl.m_title.empty()) {
+    os << tbl.m_title << '\n';
+  }
   tbl.calculate_col_widths();
   tbl.print_horizontal_border(os, table_t::border_pos_t::TOP);
   if (tbl.m_style.show_header) {
@@ -431,6 +450,9 @@ std::ostream& operator<<(std::ostream& os, const table_t& tbl)
                           i + (tbl.m_style.show_header ? 1 : 0));
   }
   tbl.print_horizontal_border(os, table_t::border_pos_t::BOTTOM);
+  if (!tbl.m_footer.empty()) {
+    os << tbl.m_footer << '\n';
+  }
   return os;
 }
 

--- a/src/include/cpp-toolbox/utils/print.hpp
+++ b/src/include/cpp-toolbox/utils/print.hpp
@@ -519,6 +519,20 @@ public:
   }
 
   /**
+   * @brief 设置表格标题 / Set table title text
+   * @param title 标题文本 / Title text
+   * @return table_t& 当前对象的引用 / Reference to this table_t
+   */
+  table_t& set_title(const std::string& title);
+
+  /**
+   * @brief 设置表格尾部文本 / Set table footer text
+   * @param footer 尾部文本 / Footer text
+   * @return table_t& 当前对象的引用 / Reference to this table_t
+   */
+  table_t& set_footer(const std::string& footer);
+
+  /**
    * @brief 设置指定列的对齐方式 / Set alignment for a specific column
    * @param column_index 列索引 / Column index
    * @param align 对齐方式 / Alignment
@@ -655,6 +669,12 @@ private:
 
   /** @brief 打印风格 / Base print style */
   print_style_t m_style;
+
+  /** @brief 表格标题文本 / Table title text */
+  std::string m_title;
+
+  /** @brief 表格尾部文本 / Table footer text */
+  std::string m_footer;
 
   /** @brief 列固定宽度映射 (col -> width) / Map of column to fixed width */
   std::unordered_map<size_t, size_t> m_col_fixed_width;


### PR DESCRIPTION
## Summary
- document table title and footer in `print_example.cpp`
- example shows how to set title and footer

## Testing
- `cmake -B build -S . -Dcpp-toolbox_DEVELOPER_MODE=ON`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure`